### PR TITLE
Doctor mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "posthog-vscode" extension will be documented in this file.
 
+## [1.0.3] - 2025-03-27
+
+### Added
+
+- Added SDK Usage Analysis mode
+- Added support for 4 usage warnings
+
 ## [1.0.2] - 2025-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the "posthog-vscode" extension will be documented in this
 - Added support for 4 usage warnings
 - Updated API key management to use VSCode Secret Storage
 
+### Removed
+- Recordings view
+
 ## [1.0.2] - 2025-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "posthog-vscode" extension will be documented in this
 
 - Added SDK Usage Analysis mode
 - Added support for 4 usage warnings
+- Updated API key management to use VSCode Secret Storage
 
 ## [1.0.2] - 2025-03-26
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This extension interacts with the PostHog API using your personal API key. Your 
 - Added SDK Usage Analysis mode
 - Added support for 4 usage warnings
 - Updated API key management to use VSCode Secret Storage
+- Removed recordings view
 
 ### 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ This extension interacts with the PostHog API using your personal API key. Your 
 
 ## Release Notes
 
+### 1.0.3
+
+- Added SDK Usage Analysis mode
+- Added support for 4 usage warnings
+
 ### 1.0.2
 
 - Added dark mode support for insight charts and visualizations

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This extension interacts with the PostHog API using your personal API key. Your 
 
 - Added SDK Usage Analysis mode
 - Added support for 4 usage warnings
+- Updated API key management to use VSCode Secret Storage
 
 ### 1.0.2
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       },
       {
         "command": "posthog.analyzeCode",
-        "title": "PostHog: Analyze Code for SDK Usage"
+        "title": "PostHog: Analyze Codebase"
       },
       {
         "command": "posthog.openFileAtLocation",
@@ -90,12 +90,8 @@
           "name": "Insights"
         },
         {
-          "id": "posthogRecordings",
-          "name": "Session Recordings"
-        },
-        {
           "id": "posthogAnalysis",
-          "name": "SDK Usage Analysis"
+          "name": "Usage Analysis"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
       {
         "command": "posthog.debugConnection",
         "title": "PostHog: Debug API Connection"
+      },
+      {
+        "command": "posthog.analyzeCode",
+        "title": "PostHog: Analyze Code for SDK Usage"
+      },
+      {
+        "command": "posthog.openFileAtLocation",
+        "title": "PostHog: Open File at Location"
       }
     ],
     "configuration": {
@@ -84,6 +92,10 @@
         {
           "id": "posthogRecordings",
           "name": "Session Recordings"
+        },
+        {
+          "id": "posthogAnalysis",
+          "name": "SDK Usage Analysis"
         }
       ]
     },
@@ -113,7 +125,8 @@
     "esbuild": "^0.25.0",
     "eslint": "^9.21.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "node-gyp": "^10.0.1"
   },
   "displayName": "PostHog",
   "engines": {
@@ -153,7 +166,8 @@
     "watch": "npm-run-all -p watch:*",
     "watch-tests": "tsc -p . -w --outDir out",
     "watch:esbuild": "node esbuild.js --watch",
-    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json"
+    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+    "rebuild": "node-gyp rebuild"
   },
   "version": "1.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -169,5 +169,5 @@
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "rebuild": "node-gyp rebuild"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -400,7 +400,7 @@ export class CodeAnalyzer {
             // Count properties by looking for property names followed by colons, handling multi-line
             const properties = propertiesObj.match(/\w+\s*:/g) || [];
             if (properties.length > MAX_PROPERTIES) {
-              return MAX_PROPERTIES_WARNING
+              return MAX_PROPERTIES_WARNING;
             }
           }
           return undefined;

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -16,10 +16,27 @@ export interface PostHogUsage {
     | "error tracking" // capture_exception
     | "configuration"; // other posthog.* = value settings
   context: string;
+  warning?: string;
 }
 
 export class CodeAnalyzer {
+  private diagnosticCollection: vscode.DiagnosticCollection;
+  private eventTrackingMap: Map<
+    string,
+    { file: string; line: number; column: number }[]
+  >;
+
+  constructor() {
+    // Create a diagnostic collection for PostHog warnings
+    this.diagnosticCollection =
+      vscode.languages.createDiagnosticCollection("posthog");
+    this.eventTrackingMap = new Map();
+  }
+
   async analyzeWorkspace(): Promise<PostHogUsage[]> {
+    // Clear previous diagnostics
+    this.diagnosticCollection.clear();
+
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders) {
       return [];
@@ -38,6 +55,9 @@ export class CodeAnalyzer {
         usages.push(...fileUsages);
       }
     }
+
+    // After analyzing, show warnings
+    this.showWarnings(usages);
 
     return this.deduplicateUsages(usages);
   }
@@ -88,11 +108,21 @@ export class CodeAnalyzer {
     // Configuration patterns (any attribute setting)
     const configurationPatterns = [/posthog\.\w+\s*=/i];
 
-    // Event tracking patterns
+    // Event tracking patterns with dynamic name detection
     const eventTrackingPatterns = [
-      /posthog\.capture\(/i,
-      /posthog\.identify\(/i,
-      /posthog\.alias\(/i,
+      {
+        pattern: /posthog\.capture\((.*?)\)/i,
+        isDynamic: (match: string) => {
+          // Check for f-strings, .format(), % formatting, string concatenation
+          return (
+            /f['"].*?[{}].*?['"]/.test(match) || // f-strings
+            /\.format\(/.test(match) || // .format()
+            /%[sd]/.test(match) || // % formatting
+            /\s*\+\s*/.test(match) || // string concatenation
+            /\$\{.*?\}/.test(match)
+          ); // template literals
+        },
+      },
     ];
 
     // Feature flag patterns
@@ -140,9 +170,26 @@ export class CodeAnalyzer {
       configurationPatterns.forEach((pattern) =>
         addUsage(pattern, "configuration")
       );
-      eventTrackingPatterns.forEach((pattern) =>
-        addUsage(pattern, "event tracking")
-      );
+      eventTrackingPatterns.forEach(({ pattern, isDynamic }) => {
+        const match = line.match(pattern);
+        if (match) {
+          const fullMatch = match[0];
+          const usage: PostHogUsage = {
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(fullMatch),
+            type: "event tracking",
+            context: fullMatch,
+          };
+
+          if (isDynamic(fullMatch)) {
+            usage.warning =
+              "Capturing events with dynamic names is not recommended";
+          }
+
+          usages.push(usage);
+        }
+      });
       featureFlagPatterns.forEach((pattern) =>
         addUsage(pattern, "feature flags")
       );
@@ -179,11 +226,31 @@ export class CodeAnalyzer {
       /posthog(?:\?)?\.initReactNativeNavigation\(/i,
     ];
 
-    // Updated event tracking patterns
+    // Updated event tracking patterns with dynamic name detection
     const eventTrackingPatterns = [
-      /posthog(?:\?)?\.capture\(/i,
-      /posthog(?:\?)?\.screen\(/i,
-      /ph-label=["'][^"']+["']/i,
+      {
+        // Update pattern to catch both quoted strings and template literals
+        pattern: /posthog(?:\?)?\.capture\(\s*(?:['"`].*?['"`])/i,
+        isDynamic: (match: string) => {
+          return (
+            /`.*?\${.*?}.*?`/.test(match) || // template literals
+            /\s*\+\s*/.test(match) || // string concatenation
+            /\(\s*[^"'`]\w+\s*\)/.test(match) // variable as event name
+          );
+        },
+        getEventName: (match: string) => {
+          // Handle both regular strings and template literals
+          const eventNameMatch = match.match(
+            /posthog(?:\?)?\.capture\(\s*([`'"'])(.*?)\1/i
+          );
+          if (eventNameMatch) {
+            const [_, quoteType, eventName] = eventNameMatch;
+            // If it's a template literal, mark it as dynamic
+            return quoteType === "`" ? null : eventName;
+          }
+          return null;
+        },
+      },
     ];
 
     // Updated user identification patterns
@@ -250,9 +317,38 @@ export class CodeAnalyzer {
       initializationPatterns.forEach((pattern) =>
         addUsage(pattern, "initialization")
       );
-      eventTrackingPatterns.forEach((pattern) =>
-        addUsage(pattern, "event tracking")
-      );
+      eventTrackingPatterns.forEach(({ pattern, isDynamic, getEventName }) => {
+        const match = line.match(pattern);
+        if (match) {
+          const fullMatch = match[0];
+          const eventName = getEventName(fullMatch);
+          const usage: PostHogUsage = {
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(fullMatch),
+            type: "event tracking",
+            context: fullMatch,
+          };
+
+          if (isDynamic(fullMatch)) {
+            usage.warning =
+              "Capturing events with dynamic names is not recommended";
+          }
+
+          // Track event name and location
+          if (eventName) {
+            const locations = this.eventTrackingMap.get(eventName) || [];
+            locations.push({
+              file: filePath,
+              line: lineNumber,
+              column: line.indexOf(fullMatch),
+            });
+            this.eventTrackingMap.set(eventName, locations);
+          }
+
+          usages.push(usage);
+        }
+      });
       userIdentificationPatterns.forEach((pattern) =>
         addUsage(pattern, "identification")
       );
@@ -268,5 +364,141 @@ export class CodeAnalyzer {
       );
       groupPatterns.forEach((pattern) => addUsage(pattern, "group analytics"));
     });
+  }
+
+  private calculateStringSimilarity(str1: string, str2: string): number {
+    // Levenshtein distance implementation
+    const matrix: number[][] = [];
+
+    for (let i = 0; i <= str1.length; i++) {
+      matrix[i] = [i];
+    }
+
+    for (let j = 0; j <= str2.length; j++) {
+      matrix[0][j] = j;
+    }
+
+    for (let i = 1; i <= str1.length; i++) {
+      for (let j = 1; j <= str2.length; j++) {
+        if (str1[i - 1] === str2[j - 1]) {
+          matrix[i][j] = matrix[i - 1][j - 1];
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1,
+            matrix[i][j - 1] + 1,
+            matrix[i - 1][j] + 1
+          );
+        }
+      }
+    }
+
+    const distance = matrix[str1.length][str2.length];
+    const maxLength = Math.max(str1.length, str2.length);
+    return 1 - distance / maxLength;
+  }
+
+  private showWarnings(usages: PostHogUsage[]) {
+    const diagnosticMap = new Map<string, vscode.Diagnostic[]>();
+    const SIMILARITY_THRESHOLD = 0.7;
+
+    // First pass: Check for similar events and update usage objects
+    for (const usage of usages) {
+      if (usage.type === "event tracking") {
+        const eventName = usage.context.match(
+          /posthog(?:\?)?\.capture\(\s*['"](.+?)['"]/i
+        )?.[1];
+
+        if (eventName) {
+          // Check all other event tracking usages for similar names
+          const similarEvents = usages
+            .filter(
+              (otherUsage) =>
+                otherUsage.type === "event tracking" &&
+                otherUsage.file !== usage.file &&
+                otherUsage !== usage
+            )
+            .map((otherUsage) => {
+              const otherEventName = otherUsage.context.match(
+                /posthog(?:\?)?\.capture\(\s*['"](.+?)['"]/i
+              )?.[1];
+              return otherEventName
+                ? {
+                    similarity: this.calculateStringSimilarity(
+                      eventName,
+                      otherEventName
+                    ),
+                    usage: otherUsage,
+                    eventName: otherEventName,
+                  }
+                : null;
+            })
+            .filter(
+              (result): result is NonNullable<typeof result> =>
+                result !== null && result.similarity >= SIMILARITY_THRESHOLD
+            );
+
+          if (similarEvents.length > 0) {
+            // Sort by similarity descending
+            similarEvents.sort((a, b) => b.similarity - a.similarity);
+            const mostSimilar = similarEvents[0];
+            const similarFile = path.basename(mostSimilar.usage.file);
+            usage.warning = `Similar event "${mostSimilar.eventName}" (${(
+              mostSimilar.similarity * 100
+            ).toFixed(1)}% similar) is tracked in ${similarFile}`;
+          }
+        }
+      }
+    }
+
+    // Second pass: Create diagnostics for all warnings
+    for (const usage of usages) {
+      if (usage.warning) {
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(
+            usage.line - 1,
+            usage.column,
+            usage.line - 1,
+            usage.column + usage.context.length
+          ),
+          `PostHog: ${usage.warning}`,
+          vscode.DiagnosticSeverity.Warning
+        );
+
+        // Add related information only for similar event warnings
+        if (usage.warning.includes("already tracking")) {
+          const similarLocation = this.eventTrackingMap
+            .get(
+              usage.context.match(
+                /posthog(?:\?)?\.capture\(\s*['"](.+?)['"]/i
+              )?.[1] || ""
+            )
+            ?.find((loc) => loc.file !== usage.file);
+
+          if (similarLocation) {
+            diagnostic.relatedInformation = [
+              new vscode.DiagnosticRelatedInformation(
+                new vscode.Location(
+                  vscode.Uri.file(similarLocation.file),
+                  new vscode.Position(
+                    similarLocation.line - 1,
+                    similarLocation.column
+                  )
+                ),
+                `Similar event tracked here`
+              ),
+            ];
+          }
+        }
+
+        const diagnostics = diagnosticMap.get(usage.file) || [];
+        diagnostics.push(diagnostic);
+        diagnosticMap.set(usage.file, diagnostics);
+      }
+    }
+
+    // Set diagnostics for each file
+    for (const [file, diagnostics] of diagnosticMap.entries()) {
+      this.diagnosticCollection.set(vscode.Uri.file(file), diagnostics);
+    }
   }
 }

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -170,67 +170,64 @@ export class CodeAnalyzer {
       /^import\s+.*from\s+['"]@posthog\/react-native['"]/i,
     ];
 
-    // Initialization patterns
+    // Updated initialization patterns
     const initializationPatterns = [
       /usePostHog\(/i,
       /<PostHogProvider[^>]*>/i,
       /new\s+PostHog\(/i,
-      /posthog\.init\(/i,
-      /posthog\.initReactNativeNavigation\(/i,
+      /posthog(?:\?)?\.init\(/i,
+      /posthog(?:\?)?\.initReactNativeNavigation\(/i,
     ];
 
-    // Event tracking patterns
+    // Updated event tracking patterns
     const eventTrackingPatterns = [
-      /posthog\.capture\(/i,
-      /posthog\.screen\(/i,
-      /ph-label=["'][^"']+["']/i, // View labeling
+      /posthog(?:\?)?\.capture\(/i,
+      /posthog(?:\?)?\.screen\(/i,
+      /ph-label=["'][^"']+["']/i,
     ];
 
-    // Event blocking patterns
-    const eventBlockingPatterns = [/ph-no-capture/i];
-
-    // User identification patterns
+    // Updated user identification patterns
     const userIdentificationPatterns = [
-      /posthog\.identify\(/i,
-      /posthog\.alias\(/i,
-      /posthog\.register\(/i,
-      /posthog\.unregister\(/i,
-      /posthog\.reset\(/i,
+      /posthog(?:\?)?\.identify\(/i,
+      /posthog(?:\?)?\.alias\(/i,
+      /posthog(?:\?)?\.register\(/i,
+      /posthog(?:\?)?\.unregister\(/i,
+      /posthog(?:\?)?\.reset\(/i,
     ];
 
-    // Data capture opt-in/out patterns
+    // Updated opt-in/out patterns
     const optInOutPatterns = [
-      /posthog\.opt_out_capturing\(/i,
-      /posthog\.opt_in_capturing\(/i,
-      /posthog\.has_opted_out_capturing\(/i,
-      /posthog\.optedOut\b/i,
-      /posthog\.optIn\(/i,
-      /posthog\.optOut\(/i,
+      /posthog(?:\?)?\.opt_out_capturing\(/i,
+      /posthog(?:\?)?\.opt_in_capturing\(/i,
+      /posthog(?:\?)?\.has_opted_out_capturing\(/i,
+      /posthog(?:\?)?\.optedOut\b/i,
+      /posthog(?:\?)?\.optIn\(/i,
+      /posthog(?:\?)?\.optOut\(/i,
     ];
 
-    // Event queue management
-    const queueManagementPatterns = [/posthog\.flush\(/i];
+    // Updated queue management patterns
+    const queueManagementPatterns = [/posthog(?:\?)?\.flush\(/i];
 
-    // Feature flag patterns
+    // Updated feature flag patterns
     const featureFlagPatterns = [
       /useFeatureFlag\(/i,
-      /posthog\.isFeatureEnabled\(/i,
-      /posthog\.getFeatureFlag\(/i,
-      /posthog\.getFeatureFlagPayload\(/i,
-      /posthog\.reloadFeatureFlagsAsync\(/i,
-      /posthog\.reloadFeatureFlags\(/i,
+      /posthog(?:\?)?\.isFeatureEnabled\(/i,
+      /posthog(?:\?)?\.getFeatureFlag\(/i,
+      /posthog(?:\?)?\.getFeatureFlagPayload\(/i,
+      /posthog(?:\?)?\.reloadFeatureFlagsAsync\(/i,
+      /posthog(?:\?)?\.reloadFeatureFlags\(/i,
     ];
 
-    // Feature flag property management
+    // Updated flag property patterns
     const flagPropertyPatterns = [
-      /posthog\.setPersonPropertiesForFlags\(/i,
-      /posthog\.resetPersonPropertiesForFlags\(/i,
-      /posthog\.setGroupPropertiesForFlags\(/i,
-      /posthog\.resetGroupPropertiesForFlags\(/i,
+      /posthog(?:\?)?\.setPersonPropertiesForFlags\(/i,
+      /posthog(?:\?)?\.resetPersonPropertiesForFlags\(/i,
+      /posthog(?:\?)?\.setGroupPropertiesForFlags\(/i,
+      /posthog(?:\?)?\.resetGroupPropertiesForFlags\(/i,
     ];
 
-    // Group analytics patterns
-    const groupPatterns = [/posthog\.group\(/i];
+    // Updated group patterns
+    const groupPatterns = [/posthog(?:\?)?\.group\(/i];
 
     lines.forEach((line, index) => {
       const lineNumber = index + 1;
@@ -255,9 +252,6 @@ export class CodeAnalyzer {
       );
       eventTrackingPatterns.forEach((pattern) =>
         addUsage(pattern, "event tracking")
-      );
-      eventBlockingPatterns.forEach((pattern) =>
-        addUsage(pattern, "configuration")
       );
       userIdentificationPatterns.forEach((pattern) =>
         addUsage(pattern, "identification")

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -14,7 +14,8 @@ export interface PostHogUsage {
     | "integration" // Django, Sentry integrations
     | "group analytics" // group_identify, group
     | "error tracking" // capture_exception
-    | "configuration"; // other posthog.* = value settings
+    | "configuration"
+    | "hook";
   context: string;
   warning?: string;
 }
@@ -103,10 +104,43 @@ export class CodeAnalyzer {
     // Import patterns
     const importPatterns = [/^import\s+posthog/i, /^from\s+posthog\s+import/i];
 
-    // Initialization patterns
+    // Helper function to check for PostHog host patterns
+    const hasPostHogHost = (line: string) => {
+      const hostPatterns = [
+        /host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /api_host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /ui_host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /\w*host\w*\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+      ];
+      return hostPatterns.some((pattern) => pattern.test(line));
+    };
+
+    // Updated initialization patterns with host checking
     const initializationPatterns = [
-      /\w+\s*=\s*PostHog\(/i,
-      /\w+\s*=\s*posthog\.PostHog\(/i,
+      {
+        pattern: /\w+\s*=\s*PostHog\((.*?)(?:\)|$)/i,
+        checkHost: (match: string, fullLine: string) => {
+          // Check if any host is explicitly set
+          const hasExplicitHost = hasPostHogHost(fullLine);
+          // Check if no host is set at all (which means it defaults to posthog.com)
+          const hasNoHost =
+            !fullLine.includes("host=") &&
+            !fullLine.includes("api_host=") &&
+            !fullLine.includes("ui_host=");
+          return hasExplicitHost || hasNoHost;
+        },
+      },
+      {
+        pattern: /\w+\s*=\s*posthog\.PostHog\((.*?)(?:\)|$)/i,
+        checkHost: (match: string, fullLine: string) => {
+          const hasExplicitHost = hasPostHogHost(fullLine);
+          const hasNoHost =
+            !fullLine.includes("host=") &&
+            !fullLine.includes("api_host=") &&
+            !fullLine.includes("ui_host=");
+          return hasExplicitHost || hasNoHost;
+        },
+      },
     ];
 
     // Configuration patterns (any attribute setting)
@@ -172,6 +206,13 @@ export class CodeAnalyzer {
       /POSTHOG_DJANGO\s*=/i,
     ];
 
+    // Updated host setting pattern to include all variants
+    const hostSettingPattern = {
+      pattern:
+        /(?:posthog|client)\.\w*host\w*\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+      type: "initialization" as const,
+    };
+
     lines.forEach((line, index) => {
       const lineNumber = index + 1;
 
@@ -191,9 +232,25 @@ export class CodeAnalyzer {
 
       // Check each pattern type with its corresponding functionality type
       importPatterns.forEach((pattern) => addUsage(pattern, "import"));
-      initializationPatterns.forEach((pattern) =>
-        addUsage(pattern, "initialization")
-      );
+      initializationPatterns.forEach(({ pattern, checkHost }) => {
+        const match = line.match(pattern);
+        if (match) {
+          const usage: PostHogUsage = {
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(match[0]),
+            type: "initialization",
+            context: match[0],
+          };
+
+          if (checkHost(match[0], line)) {
+            usage.warning =
+              "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+          }
+
+          usages.push(usage);
+        }
+      });
       configurationPatterns.forEach((pattern) =>
         addUsage(pattern, "configuration")
       );
@@ -230,12 +287,20 @@ export class CodeAnalyzer {
         addUsage(pattern, "feature flags")
       );
       groupPatterns.forEach((pattern) => addUsage(pattern, "group analytics"));
-      errorTrackingPatterns.forEach((pattern) =>
-        addUsage(pattern, "error tracking")
-      );
-      integrationPatterns.forEach((pattern) =>
-        addUsage(pattern, "integration")
-      );
+
+      // Check direct host setting
+      const hostMatch = line.match(hostSettingPattern.pattern);
+      if (hostMatch) {
+        usages.push({
+          file: filePath,
+          line: lineNumber,
+          column: line.indexOf(hostMatch[0]),
+          type: hostSettingPattern.type,
+          context: hostMatch[0],
+          warning:
+            "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy",
+        });
+      }
     });
   }
 
@@ -253,13 +318,62 @@ export class CodeAnalyzer {
       /^import\s+.*from\s+['"]@posthog\/react-native['"]/i,
     ];
 
-    // Updated initialization patterns
+    // Helper function to check for PostHog host patterns
+    const hasPostHogHost = (line: string) => {
+      const hostPatterns = [
+        /host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /api_host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /ui_host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+        /\w*host\w*\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+      ];
+      return hostPatterns.some((pattern) => pattern.test(line));
+    };
+
+    // Remove usePostHog from initialization patterns and create new hook patterns
+    const hookPatterns = [
+      {
+        pattern: /usePostHog\((.*?)(?:\)|$)/i,
+        type: "hook" as const,
+      },
+    ];
+
     const initializationPatterns = [
-      /usePostHog\(/i,
-      /<PostHogProvider[^>]*>/i,
-      /new\s+PostHog\(/i,
-      /posthog(?:\?)?\.init\(/i,
-      /posthog(?:\?)?\.initReactNativeNavigation\(/i,
+      {
+        pattern: /<PostHogProvider[^>]*>/i,
+        checkHost: (match: string, fullLine: string) => {
+          const hasExplicitHost = hasPostHogHost(fullLine);
+          const hasNoHost =
+            !fullLine.includes("host=") &&
+            !fullLine.includes("host:") &&
+            !fullLine.includes("api_host") &&
+            !fullLine.includes("ui_host");
+          return hasExplicitHost || hasNoHost;
+        },
+      },
+      {
+        pattern: /new\s+PostHog\((.*?)(?:\)|$)/i,
+        checkHost: (match: string, fullLine: string) => {
+          const hasExplicitHost = hasPostHogHost(fullLine);
+          const hasNoHost =
+            !fullLine.includes("host:") &&
+            !fullLine.includes("host=") &&
+            !fullLine.includes("api_host") &&
+            !fullLine.includes("ui_host");
+          return hasExplicitHost || hasNoHost;
+        },
+      },
+      {
+        pattern: /posthog(?:\?)?\.init\((.*?)(?:\)|$)/i,
+        checkHost: (match: string, fullLine: string) => {
+          const hasExplicitHost = hasPostHogHost(fullLine);
+          const hasNoHost =
+            !fullLine.includes("host:") &&
+            !fullLine.includes("host=") &&
+            !fullLine.includes("api_host") &&
+            !fullLine.includes("ui_host");
+          return hasExplicitHost || hasNoHost;
+        },
+      },
     ];
 
     // Updated event tracking patterns with dynamic name detection
@@ -359,6 +473,13 @@ export class CodeAnalyzer {
     // Updated group patterns
     const groupPatterns = [/posthog(?:\?)?\.group\(/i];
 
+    // Updated host setting pattern to include all variants
+    const hostSettingPattern = {
+      pattern:
+        /(?:posthog|client)\.\w*host\w*\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
+      type: "initialization" as const,
+    };
+
     lines.forEach((line, index) => {
       const lineNumber = index + 1;
 
@@ -377,9 +498,25 @@ export class CodeAnalyzer {
 
       // Check each pattern type
       importPatterns.forEach((pattern) => addUsage(pattern, "import"));
-      initializationPatterns.forEach((pattern) =>
-        addUsage(pattern, "initialization")
-      );
+      initializationPatterns.forEach(({ pattern, checkHost }) => {
+        const match = line.match(pattern);
+        if (match) {
+          const usage: PostHogUsage = {
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(match[0]),
+            type: "initialization",
+            context: match[0],
+          };
+
+          if (checkHost(match[0], line)) {
+            usage.warning =
+              "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+          }
+
+          usages.push(usage);
+        }
+      });
       eventTrackingPatterns.forEach(
         ({ pattern, isDynamic, getEventName, checkProperties }) => {
           const match = line.match(pattern);
@@ -435,6 +572,23 @@ export class CodeAnalyzer {
         addUsage(pattern, "feature flags")
       );
       groupPatterns.forEach((pattern) => addUsage(pattern, "group analytics"));
+
+      // Check direct host setting
+      const hostMatch = line.match(hostSettingPattern.pattern);
+      if (hostMatch) {
+        usages.push({
+          file: filePath,
+          line: lineNumber,
+          column: line.indexOf(hostMatch[0]),
+          type: hostSettingPattern.type,
+          context: hostMatch[0],
+          warning:
+            "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy",
+        });
+      }
+
+      // Add hook pattern check
+      hookPatterns.forEach(({ pattern, type }) => addUsage(pattern, type));
     });
   }
 

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -24,6 +24,9 @@ const DYNAMIC_EVENT_WARNING =
   "Capturing events with dynamic names is not recommended";
 const REVERSE_PROXY_WARNING =
   "You are using PostHog's host directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+const MAX_PROPERTIES_WARNING =
+  "Event is tracking too many properties, recommended max: 25";
+const MAX_PROPERTIES = 25;
 
 export class CodeAnalyzer {
   private diagnosticCollection: vscode.DiagnosticCollection;
@@ -178,8 +181,8 @@ export class CodeAnalyzer {
             const properties = propertiesMatch[1]
               .split(",")
               .filter((p) => p.trim());
-            if (properties.length > 25) {
-              return `Event is tracking ${properties.length} properties (recommended max: 25)`;
+            if (properties.length > MAX_PROPERTIES) {
+              return MAX_PROPERTIES_WARNING;
             }
           }
           // Check for direct dict as third argument
@@ -188,8 +191,8 @@ export class CodeAnalyzer {
             const properties = directPropsMatch[1]
               .split(",")
               .filter((p) => p.trim());
-            if (properties.length > 25) {
-              return `Event is tracking ${properties.length} properties (recommended max: 25)`;
+            if (properties.length > MAX_PROPERTIES) {
+              return MAX_PROPERTIES_WARNING;
             }
           }
           return undefined;
@@ -396,8 +399,8 @@ export class CodeAnalyzer {
             const propertiesObj = propertiesMatch[1];
             // Count properties by looking for property names followed by colons, handling multi-line
             const properties = propertiesObj.match(/\w+\s*:/g) || [];
-            if (properties.length > 25) {
-              return `Event is tracking ${properties.length} properties, recommended max: 25`;
+            if (properties.length > MAX_PROPERTIES) {
+              return MAX_PROPERTIES_WARNING
             }
           }
           return undefined;

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -56,10 +56,14 @@ export class CodeAnalyzer {
       }
     }
 
-    // After analyzing, show warnings
-    this.showWarnings(usages);
+    // Deduplicate before showing warnings
+    const dedupedUsages = this.deduplicateUsages(usages);
 
-    return this.deduplicateUsages(usages);
+    // After analyzing, show warnings
+    this.showWarnings(dedupedUsages);
+
+    // Return the deduped usages directly - no need to split warnings
+    return dedupedUsages;
   }
 
   private deduplicateUsages(usages: PostHogUsage[]): PostHogUsage[] {
@@ -108,10 +112,10 @@ export class CodeAnalyzer {
     // Configuration patterns (any attribute setting)
     const configurationPatterns = [/posthog\.\w+\s*=/i];
 
-    // Event tracking patterns with dynamic name detection
+    // Event tracking patterns with dynamic name and property detection
     const eventTrackingPatterns = [
       {
-        pattern: /posthog\.capture\((.*?)\)/i,
+        pattern: /posthog\.capture\((.*?)(?:\)|$)/i,
         isDynamic: (match: string) => {
           // Check for f-strings, .format(), % formatting, string concatenation
           return (
@@ -121,6 +125,29 @@ export class CodeAnalyzer {
             /\s*\+\s*/.test(match) || // string concatenation
             /\$\{.*?\}/.test(match)
           ); // template literals
+        },
+        checkProperties: (match: string) => {
+          // Check for properties in Python dict format
+          const propertiesMatch = match.match(/properties\s*=\s*{([^}]*)}/);
+          if (propertiesMatch) {
+            const properties = propertiesMatch[1]
+              .split(",")
+              .filter((p) => p.trim());
+            if (properties.length > 25) {
+              return `Event is tracking ${properties.length} properties (recommended max: 25)`;
+            }
+          }
+          // Check for direct dict as third argument
+          const directPropsMatch = match.match(/,\s*{([^}]*)}/);
+          if (directPropsMatch) {
+            const properties = directPropsMatch[1]
+              .split(",")
+              .filter((p) => p.trim());
+            if (properties.length > 25) {
+              return `Event is tracking ${properties.length} properties (recommended max: 25)`;
+            }
+          }
+          return undefined;
         },
       },
     ];
@@ -170,26 +197,35 @@ export class CodeAnalyzer {
       configurationPatterns.forEach((pattern) =>
         addUsage(pattern, "configuration")
       );
-      eventTrackingPatterns.forEach(({ pattern, isDynamic }) => {
-        const match = line.match(pattern);
-        if (match) {
-          const fullMatch = match[0];
-          const usage: PostHogUsage = {
-            file: filePath,
-            line: lineNumber,
-            column: line.indexOf(fullMatch),
-            type: "event tracking",
-            context: fullMatch,
-          };
+      eventTrackingPatterns.forEach(
+        ({ pattern, isDynamic, checkProperties }) => {
+          const match = line.match(pattern);
+          if (match) {
+            const fullMatch = match[0];
+            const usage: PostHogUsage = {
+              file: filePath,
+              line: lineNumber,
+              column: line.indexOf(fullMatch),
+              type: "event tracking",
+              context: fullMatch,
+            };
 
-          if (isDynamic(fullMatch)) {
-            usage.warning =
-              "Capturing events with dynamic names is not recommended";
+            if (isDynamic(fullMatch)) {
+              usage.warning =
+                "Capturing events with dynamic names is not recommended";
+            }
+
+            const propertyWarning = checkProperties?.(fullMatch);
+            if (propertyWarning) {
+              usage.warning = usage.warning
+                ? `${usage.warning}; ${propertyWarning}`
+                : propertyWarning;
+            }
+
+            usages.push(usage);
           }
-
-          usages.push(usage);
         }
-      });
+      );
       featureFlagPatterns.forEach((pattern) =>
         addUsage(pattern, "feature flags")
       );
@@ -229,7 +265,6 @@ export class CodeAnalyzer {
     // Updated event tracking patterns with dynamic name detection
     const eventTrackingPatterns = [
       {
-        // Update pattern to catch both quoted strings and template literals
         pattern: /posthog(?:\?)?\.capture\(\s*(?:['"`].*?['"`])/i,
         isDynamic: (match: string) => {
           return (
@@ -249,6 +284,34 @@ export class CodeAnalyzer {
             return quoteType === "`" ? null : eventName;
           }
           return null;
+        },
+        checkProperties: (match: string, line: string, lineIndex: number) => {
+          // Look for properties in current and next few lines
+          let fullCall = line;
+          let curIndex = lineIndex;
+          let bracketCount =
+            (line.match(/{/g) || []).length - (line.match(/}/g) || []).length;
+
+          // Keep adding lines until we find the matching closing bracket
+          while (bracketCount > 0 && curIndex + 1 < lines.length) {
+            curIndex++;
+            const nextLine = lines[curIndex];
+            fullCall += "\n" + nextLine;
+            bracketCount += (nextLine.match(/{/g) || []).length;
+            bracketCount -= (nextLine.match(/}/g) || []).length;
+          }
+
+          // Now look for the properties object in the full call
+          const propertiesMatch = fullCall.match(/,\s*({[\s\S]*?})/);
+          if (propertiesMatch) {
+            const propertiesObj = propertiesMatch[1];
+            // Count properties by looking for property names followed by colons, handling multi-line
+            const properties = propertiesObj.match(/\w+\s*:/g) || [];
+            if (properties.length > 25) {
+              return `Event is tracking ${properties.length} properties, recommended max: 25`;
+            }
+          }
+          return undefined;
         },
       },
     ];
@@ -317,38 +380,47 @@ export class CodeAnalyzer {
       initializationPatterns.forEach((pattern) =>
         addUsage(pattern, "initialization")
       );
-      eventTrackingPatterns.forEach(({ pattern, isDynamic, getEventName }) => {
-        const match = line.match(pattern);
-        if (match) {
-          const fullMatch = match[0];
-          const eventName = getEventName(fullMatch);
-          const usage: PostHogUsage = {
-            file: filePath,
-            line: lineNumber,
-            column: line.indexOf(fullMatch),
-            type: "event tracking",
-            context: fullMatch,
-          };
-
-          if (isDynamic(fullMatch)) {
-            usage.warning =
-              "Capturing events with dynamic names is not recommended";
-          }
-
-          // Track event name and location
-          if (eventName) {
-            const locations = this.eventTrackingMap.get(eventName) || [];
-            locations.push({
+      eventTrackingPatterns.forEach(
+        ({ pattern, isDynamic, getEventName, checkProperties }) => {
+          const match = line.match(pattern);
+          if (match) {
+            const fullMatch = match[0];
+            const eventName = getEventName?.(fullMatch);
+            const usage: PostHogUsage = {
               file: filePath,
               line: lineNumber,
               column: line.indexOf(fullMatch),
-            });
-            this.eventTrackingMap.set(eventName, locations);
-          }
+              type: "event tracking",
+              context: fullMatch,
+            };
 
-          usages.push(usage);
+            if (isDynamic(fullMatch)) {
+              usage.warning =
+                "Capturing events with dynamic names is not recommended";
+            }
+
+            const propertyWarning = checkProperties?.(fullMatch, line, index);
+            if (propertyWarning) {
+              usage.warning = usage.warning
+                ? `${usage.warning}; ${propertyWarning}`
+                : propertyWarning;
+            }
+
+            // Track event name and location
+            if (eventName) {
+              const locations = this.eventTrackingMap.get(eventName) || [];
+              locations.push({
+                file: filePath,
+                line: lineNumber,
+                column: line.indexOf(fullMatch),
+              });
+              this.eventTrackingMap.set(eventName, locations);
+            }
+
+            usages.push(usage);
+          }
         }
-      });
+      );
       userIdentificationPatterns.forEach((pattern) =>
         addUsage(pattern, "identification")
       );
@@ -442,9 +514,14 @@ export class CodeAnalyzer {
             similarEvents.sort((a, b) => b.similarity - a.similarity);
             const mostSimilar = similarEvents[0];
             const similarFile = path.basename(mostSimilar.usage.file);
-            usage.warning = `Similar event "${mostSimilar.eventName}" (${(
-              mostSimilar.similarity * 100
-            ).toFixed(1)}% similar) is tracked in ${similarFile}`;
+            const similarWarning = `Similar event "${
+              mostSimilar.eventName
+            }" (${(mostSimilar.similarity * 100).toFixed(
+              1
+            )}% similar) is tracked in ${similarFile}`;
+            usage.warning = usage.warning
+              ? `${usage.warning}; ${similarWarning}`
+              : similarWarning;
           }
         }
       }
@@ -453,45 +530,53 @@ export class CodeAnalyzer {
     // Second pass: Create diagnostics for all warnings
     for (const usage of usages) {
       if (usage.warning) {
-        const diagnostic = new vscode.Diagnostic(
-          new vscode.Range(
-            usage.line - 1,
-            usage.column,
-            usage.line - 1,
-            usage.column + usage.context.length
-          ),
-          `PostHog: ${usage.warning}`,
-          vscode.DiagnosticSeverity.Warning
-        );
+        // Split multiple warnings and create a diagnostic for each
+        const warnings = usage.warning.split(";").map((w) => w.trim());
+        const diagnostics = diagnosticMap.get(usage.file) || [];
 
-        // Add related information only for similar event warnings
-        if (usage.warning.includes("already tracking")) {
-          const similarLocation = this.eventTrackingMap
-            .get(
-              usage.context.match(
-                /posthog(?:\?)?\.capture\(\s*['"](.+?)['"]/i
-              )?.[1] || ""
-            )
-            ?.find((loc) => loc.file !== usage.file);
+        for (const warning of warnings) {
+          if (!warning) continue; // Skip empty warnings
 
-          if (similarLocation) {
-            diagnostic.relatedInformation = [
-              new vscode.DiagnosticRelatedInformation(
-                new vscode.Location(
-                  vscode.Uri.file(similarLocation.file),
-                  new vscode.Position(
-                    similarLocation.line - 1,
-                    similarLocation.column
-                  )
+          const diagnostic = new vscode.Diagnostic(
+            new vscode.Range(
+              usage.line - 1,
+              usage.column,
+              usage.line - 1,
+              usage.column + usage.context.length
+            ),
+            `PostHog: ${warning}`,
+            vscode.DiagnosticSeverity.Warning
+          );
+
+          // Add related information only for similar event warnings
+          if (warning.includes("Similar event")) {
+            const similarLocation = this.eventTrackingMap
+              .get(
+                usage.context.match(
+                  /posthog(?:\?)?\.capture\(\s*['"](.+?)['"]/i
+                )?.[1] || ""
+              )
+              ?.find((loc) => loc.file !== usage.file);
+
+            if (similarLocation) {
+              diagnostic.relatedInformation = [
+                new vscode.DiagnosticRelatedInformation(
+                  new vscode.Location(
+                    vscode.Uri.file(similarLocation.file),
+                    new vscode.Position(
+                      similarLocation.line - 1,
+                      similarLocation.column
+                    )
+                  ),
+                  `Similar event tracked here`
                 ),
-                `Similar event tracked here`
-              ),
-            ];
+              ];
+            }
           }
+
+          diagnostics.push(diagnostic);
         }
 
-        const diagnostics = diagnosticMap.get(usage.file) || [];
-        diagnostics.push(diagnostic);
         diagnosticMap.set(usage.file, diagnostics);
       }
     }

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -20,12 +20,19 @@ export interface PostHogUsage {
   warning?: string;
 }
 
+const DYNAMIC_EVENT_WARNING =
+  "Capturing events with dynamic names is not recommended";
+const REVERSE_PROXY_WARNING =
+  "You are using PostHog's host directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+
 export class CodeAnalyzer {
   private diagnosticCollection: vscode.DiagnosticCollection;
   private eventTrackingMap: Map<
     string,
     { file: string; line: number; column: number }[]
   >;
+  private foundPosthogHost: boolean = false;
+  private foundAnyHost: boolean = false;
 
   constructor() {
     // Create a diagnostic collection for PostHog warnings
@@ -35,8 +42,10 @@ export class CodeAnalyzer {
   }
 
   async analyzeWorkspace(): Promise<PostHogUsage[]> {
-    // Clear previous diagnostics
+    // Clear previous diagnostics and reset host tracking
     this.diagnosticCollection.clear();
+    this.foundPosthogHost = false;
+    this.foundAnyHost = false;
 
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders) {
@@ -45,6 +54,31 @@ export class CodeAnalyzer {
 
     const usages: PostHogUsage[] = [];
 
+    // First pass: scan for host settings
+    for (const folder of workspaceFolders) {
+      const files = await vscode.workspace.findFiles(
+        new vscode.RelativePattern(folder, "**/*.{py,ts,tsx}"),
+        "**/node_modules/**"
+      );
+
+      for (const file of files) {
+        const content = await vscode.workspace.fs.readFile(file);
+        const text = new TextDecoder().decode(content);
+
+        this.checkHostSettings(text);
+
+        // If we found a posthog.com host, we can stop searching as we'll need to show warnings
+        if (this.foundPosthogHost) {
+          break;
+        }
+      }
+
+      if (this.foundPosthogHost) {
+        break;
+      }
+    }
+
+    // Second pass: normal analysis
     for (const folder of workspaceFolders) {
       const files = await vscode.workspace.findFiles(
         new vscode.RelativePattern(folder, "**/*.{py,ts,tsx}"),
@@ -104,41 +138,18 @@ export class CodeAnalyzer {
     // Import patterns
     const importPatterns = [/^import\s+posthog/i, /^from\s+posthog\s+import/i];
 
-    // Helper function to check for PostHog host patterns
-    const hasPostHogHost = (line: string) => {
-      const hostPatterns = [
-        /host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /api_host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /ui_host\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /\w*host\w*\s*=\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-      ];
-      return hostPatterns.some((pattern) => pattern.test(line));
-    };
-
-    // Updated initialization patterns with host checking
+    // Add initialization patterns back
     const initializationPatterns = [
       {
         pattern: /\w+\s*=\s*PostHog\((.*?)(?:\)|$)/i,
-        checkHost: (match: string, fullLine: string) => {
-          // Check if any host is explicitly set
-          const hasExplicitHost = hasPostHogHost(fullLine);
-          // Check if no host is set at all (which means it defaults to posthog.com)
-          const hasNoHost =
-            !fullLine.includes("host=") &&
-            !fullLine.includes("api_host=") &&
-            !fullLine.includes("ui_host=");
-          return hasExplicitHost || hasNoHost;
+        checkHost: () => {
+          return this.foundPosthogHost || !this.foundAnyHost;
         },
       },
       {
         pattern: /\w+\s*=\s*posthog\.PostHog\((.*?)(?:\)|$)/i,
-        checkHost: (match: string, fullLine: string) => {
-          const hasExplicitHost = hasPostHogHost(fullLine);
-          const hasNoHost =
-            !fullLine.includes("host=") &&
-            !fullLine.includes("api_host=") &&
-            !fullLine.includes("ui_host=");
-          return hasExplicitHost || hasNoHost;
+        checkHost: () => {
+          return this.foundPosthogHost || !this.foundAnyHost;
         },
       },
     ];
@@ -200,12 +211,6 @@ export class CodeAnalyzer {
     // Error tracking patterns
     const errorTrackingPatterns = [/posthog\.capture_exception\(/i];
 
-    // Integration patterns
-    const integrationPatterns = [
-      /PostHogIntegration\(\)/i,
-      /POSTHOG_DJANGO\s*=/i,
-    ];
-
     // Updated host setting pattern to include all variants
     const hostSettingPattern = {
       pattern:
@@ -230,8 +235,10 @@ export class CodeAnalyzer {
         }
       };
 
-      // Check each pattern type with its corresponding functionality type
+      // Check each pattern type
       importPatterns.forEach((pattern) => addUsage(pattern, "import"));
+
+      // Add initialization pattern checks back
       initializationPatterns.forEach(({ pattern, checkHost }) => {
         const match = line.match(pattern);
         if (match) {
@@ -243,9 +250,8 @@ export class CodeAnalyzer {
             context: match[0],
           };
 
-          if (checkHost(match[0], line)) {
-            usage.warning =
-              "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+          if (checkHost()) {
+            usage.warning = REVERSE_PROXY_WARNING;
           }
 
           usages.push(usage);
@@ -268,8 +274,7 @@ export class CodeAnalyzer {
             };
 
             if (isDynamic(fullMatch)) {
-              usage.warning =
-                "Capturing events with dynamic names is not recommended";
+              usage.warning = DYNAMIC_EVENT_WARNING;
             }
 
             const propertyWarning = checkProperties?.(fullMatch);
@@ -297,8 +302,7 @@ export class CodeAnalyzer {
           column: line.indexOf(hostMatch[0]),
           type: hostSettingPattern.type,
           context: hostMatch[0],
-          warning:
-            "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy",
+          warning: REVERSE_PROXY_WARNING,
         });
       }
     });
@@ -318,17 +322,6 @@ export class CodeAnalyzer {
       /^import\s+.*from\s+['"]@posthog\/react-native['"]/i,
     ];
 
-    // Helper function to check for PostHog host patterns
-    const hasPostHogHost = (line: string) => {
-      const hostPatterns = [
-        /host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /api_host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /ui_host\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-        /\w*host\w*\s*[=:]\s*['"].*?(?:posthog\.com|i\.posthog\.com)/i,
-      ];
-      return hostPatterns.some((pattern) => pattern.test(line));
-    };
-
     // Remove usePostHog from initialization patterns and create new hook patterns
     const hookPatterns = [
       {
@@ -340,38 +333,20 @@ export class CodeAnalyzer {
     const initializationPatterns = [
       {
         pattern: /<PostHogProvider[^>]*>/i,
-        checkHost: (match: string, fullLine: string) => {
-          const hasExplicitHost = hasPostHogHost(fullLine);
-          const hasNoHost =
-            !fullLine.includes("host=") &&
-            !fullLine.includes("host:") &&
-            !fullLine.includes("api_host") &&
-            !fullLine.includes("ui_host");
-          return hasExplicitHost || hasNoHost;
+        checkHost: () => {
+          return this.foundPosthogHost || !this.foundAnyHost;
         },
       },
       {
         pattern: /new\s+PostHog\((.*?)(?:\)|$)/i,
-        checkHost: (match: string, fullLine: string) => {
-          const hasExplicitHost = hasPostHogHost(fullLine);
-          const hasNoHost =
-            !fullLine.includes("host:") &&
-            !fullLine.includes("host=") &&
-            !fullLine.includes("api_host") &&
-            !fullLine.includes("ui_host");
-          return hasExplicitHost || hasNoHost;
+        checkHost: () => {
+          return this.foundPosthogHost || !this.foundAnyHost;
         },
       },
       {
         pattern: /posthog(?:\?)?\.init\((.*?)(?:\)|$)/i,
-        checkHost: (match: string, fullLine: string) => {
-          const hasExplicitHost = hasPostHogHost(fullLine);
-          const hasNoHost =
-            !fullLine.includes("host:") &&
-            !fullLine.includes("host=") &&
-            !fullLine.includes("api_host") &&
-            !fullLine.includes("ui_host");
-          return hasExplicitHost || hasNoHost;
+        checkHost: () => {
+          return this.foundPosthogHost || !this.foundAnyHost;
         },
       },
     ];
@@ -509,9 +484,8 @@ export class CodeAnalyzer {
             context: match[0],
           };
 
-          if (checkHost(match[0], line)) {
-            usage.warning =
-              "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy";
+          if (checkHost()) {
+            usage.warning = REVERSE_PROXY_WARNING;
           }
 
           usages.push(usage);
@@ -532,8 +506,7 @@ export class CodeAnalyzer {
             };
 
             if (isDynamic(fullMatch)) {
-              usage.warning =
-                "Capturing events with dynamic names is not recommended";
+              usage.warning = DYNAMIC_EVENT_WARNING;
             }
 
             const propertyWarning = checkProperties?.(fullMatch, line, index);
@@ -582,8 +555,7 @@ export class CodeAnalyzer {
           column: line.indexOf(hostMatch[0]),
           type: hostSettingPattern.type,
           context: hostMatch[0],
-          warning:
-            "You are calling PostHog directly, which is not recommended. You should use a reverse proxy to call PostHog, see: https://posthog.com/docs/advanced/proxy",
+          warning: REVERSE_PROXY_WARNING,
         });
       }
 
@@ -689,7 +661,9 @@ export class CodeAnalyzer {
         const diagnostics = diagnosticMap.get(usage.file) || [];
 
         for (const warning of warnings) {
-          if (!warning) continue; // Skip empty warnings
+          if (!warning) {
+            continue;
+          } // Skip empty warnings
 
           const diagnostic = new vscode.Diagnostic(
             new vscode.Range(
@@ -738,6 +712,36 @@ export class CodeAnalyzer {
     // Set diagnostics for each file
     for (const [file, diagnostics] of diagnosticMap.entries()) {
       this.diagnosticCollection.set(vscode.Uri.file(file), diagnostics);
+    }
+  }
+
+  private checkHostSettings(text: string): void {
+    // Combined pattern for both Python and TypeScript syntax, including variable assignments
+    const hostPatterns = [
+      // String literal assignments
+      /(?:host|api_host|ui_host)\s*[=:]\s*['"]([^'"]*)['"]/i,
+      // Variable/constant assignments
+      /(?:host|api_host|ui_host)\s*[=:]\s*([A-Z_][A-Z0-9_]*|\w+(?:\.\w+)*)\b/i,
+    ];
+
+    for (const pattern of hostPatterns) {
+      const matches = text.matchAll(new RegExp(pattern, "g"));
+      for (const match of matches) {
+        this.foundAnyHost = true;
+        // If it's a string literal and contains posthog.com
+        if (
+          match[1] &&
+          typeof match[1] === "string" &&
+          match[1].includes("posthog.com")
+        ) {
+          this.foundPosthogHost = true;
+          return;
+        }
+        // If it's a variable assignment, we consider it a custom host
+        if (match[1] && !match[1].match(/['"`]/)) {
+          return; // Found a variable assignment, treat it as a custom host
+        }
+      }
     }
   }
 }

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -1,0 +1,278 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+export interface PostHogUsage {
+  file: string;
+  line: number;
+  column: number;
+  type:
+    | "import"
+    | "event tracking" // capture, identify, alias
+    | "identification" // identify, alias, register, unregister, reset
+    | "feature flags" // feature_enabled, get_feature_flag, etc.
+    | "initialization" // PostHog(), init(), api_key setting
+    | "integration" // Django, Sentry integrations
+    | "group analytics" // group_identify, group
+    | "error tracking" // capture_exception
+    | "configuration"; // other posthog.* = value settings
+  context: string;
+}
+
+export class CodeAnalyzer {
+  async analyzeWorkspace(): Promise<PostHogUsage[]> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders) {
+      return [];
+    }
+
+    const usages: PostHogUsage[] = [];
+
+    for (const folder of workspaceFolders) {
+      const files = await vscode.workspace.findFiles(
+        new vscode.RelativePattern(folder, "**/*.{py,ts,tsx}"),
+        "**/node_modules/**"
+      );
+
+      for (const file of files) {
+        const fileUsages = await this.analyzeFile(file);
+        usages.push(...fileUsages);
+      }
+    }
+
+    return this.deduplicateUsages(usages);
+  }
+
+  private deduplicateUsages(usages: PostHogUsage[]): PostHogUsage[] {
+    const seen = new Set<string>();
+    return usages.filter((usage) => {
+      const key = `${usage.file}:${usage.line}:${usage.column}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }
+
+  private async analyzeFile(file: vscode.Uri): Promise<PostHogUsage[]> {
+    const content = await vscode.workspace.fs.readFile(file);
+    const text = new TextDecoder().decode(content);
+    const ext = path.extname(file.fsPath).toLowerCase();
+    const usages: PostHogUsage[] = [];
+
+    if (ext === ".py") {
+      this.analyzePythonFile(text, file.fsPath, usages);
+    } else if (ext === ".ts" || ext === ".tsx") {
+      this.analyzeTypeScriptFile(text, file.fsPath, usages);
+    }
+
+    return this.deduplicateUsages(usages);
+  }
+
+  private analyzePythonFile(
+    text: string,
+    filePath: string,
+    usages: PostHogUsage[]
+  ) {
+    const lines = text.split("\n");
+
+    // Import patterns
+    const importPatterns = [/^import\s+posthog/i, /^from\s+posthog\s+import/i];
+
+    // Initialization patterns
+    const initializationPatterns = [
+      /\w+\s*=\s*PostHog\(/i,
+      /\w+\s*=\s*posthog\.PostHog\(/i,
+    ];
+
+    // Configuration patterns (any attribute setting)
+    const configurationPatterns = [/posthog\.\w+\s*=/i];
+
+    // Event tracking patterns
+    const eventTrackingPatterns = [
+      /posthog\.capture\(/i,
+      /posthog\.identify\(/i,
+      /posthog\.alias\(/i,
+    ];
+
+    // Feature flag patterns
+    const featureFlagPatterns = [
+      /posthog\.feature_enabled\(/i,
+      /posthog\.get_feature_flag\(/i,
+      /posthog\.get_all_flags\(/i,
+      /posthog\.get_all_flags_and_payloads\(/i,
+    ];
+
+    // Group analytics patterns
+    const groupPatterns = [/posthog\.group_identify\(/i];
+
+    // Error tracking patterns
+    const errorTrackingPatterns = [/posthog\.capture_exception\(/i];
+
+    // Integration patterns
+    const integrationPatterns = [
+      /PostHogIntegration\(\)/i,
+      /POSTHOG_DJANGO\s*=/i,
+    ];
+
+    lines.forEach((line, index) => {
+      const lineNumber = index + 1;
+
+      // Helper function to add usage
+      const addUsage = (pattern: RegExp, type: PostHogUsage["type"]) => {
+        const match = line.match(pattern);
+        if (match) {
+          usages.push({
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(match[0]),
+            type,
+            context: match[0],
+          });
+        }
+      };
+
+      // Check each pattern type with its corresponding functionality type
+      importPatterns.forEach((pattern) => addUsage(pattern, "import"));
+      initializationPatterns.forEach((pattern) =>
+        addUsage(pattern, "initialization")
+      );
+      configurationPatterns.forEach((pattern) =>
+        addUsage(pattern, "configuration")
+      );
+      eventTrackingPatterns.forEach((pattern) =>
+        addUsage(pattern, "event tracking")
+      );
+      featureFlagPatterns.forEach((pattern) =>
+        addUsage(pattern, "feature flags")
+      );
+      groupPatterns.forEach((pattern) => addUsage(pattern, "group analytics"));
+      errorTrackingPatterns.forEach((pattern) =>
+        addUsage(pattern, "error tracking")
+      );
+      integrationPatterns.forEach((pattern) =>
+        addUsage(pattern, "integration")
+      );
+    });
+  }
+
+  private analyzeTypeScriptFile(
+    text: string,
+    filePath: string,
+    usages: PostHogUsage[]
+  ) {
+    const lines = text.split("\n");
+
+    // Import patterns
+    const importPatterns = [
+      /^import\s+.*from\s+['"]posthog-js['"]/i,
+      /^import\s+.*from\s+['"]posthog['"]/i,
+      /^import\s+.*from\s+['"]@posthog\/react-native['"]/i,
+    ];
+
+    // Initialization patterns
+    const initializationPatterns = [
+      /usePostHog\(/i,
+      /<PostHogProvider[^>]*>/i,
+      /new\s+PostHog\(/i,
+      /posthog\.init\(/i,
+      /posthog\.initReactNativeNavigation\(/i,
+    ];
+
+    // Event tracking patterns
+    const eventTrackingPatterns = [
+      /posthog\.capture\(/i,
+      /posthog\.screen\(/i,
+      /ph-label=["'][^"']+["']/i, // View labeling
+    ];
+
+    // Event blocking patterns
+    const eventBlockingPatterns = [/ph-no-capture/i];
+
+    // User identification patterns
+    const userIdentificationPatterns = [
+      /posthog\.identify\(/i,
+      /posthog\.alias\(/i,
+      /posthog\.register\(/i,
+      /posthog\.unregister\(/i,
+      /posthog\.reset\(/i,
+    ];
+
+    // Data capture opt-in/out patterns
+    const optInOutPatterns = [
+      /posthog\.opt_out_capturing\(/i,
+      /posthog\.opt_in_capturing\(/i,
+      /posthog\.has_opted_out_capturing\(/i,
+      /posthog\.optedOut\b/i,
+      /posthog\.optIn\(/i,
+      /posthog\.optOut\(/i,
+    ];
+
+    // Event queue management
+    const queueManagementPatterns = [/posthog\.flush\(/i];
+
+    // Feature flag patterns
+    const featureFlagPatterns = [
+      /useFeatureFlag\(/i,
+      /posthog\.isFeatureEnabled\(/i,
+      /posthog\.getFeatureFlag\(/i,
+      /posthog\.getFeatureFlagPayload\(/i,
+      /posthog\.reloadFeatureFlagsAsync\(/i,
+      /posthog\.reloadFeatureFlags\(/i,
+    ];
+
+    // Feature flag property management
+    const flagPropertyPatterns = [
+      /posthog\.setPersonPropertiesForFlags\(/i,
+      /posthog\.resetPersonPropertiesForFlags\(/i,
+      /posthog\.setGroupPropertiesForFlags\(/i,
+      /posthog\.resetGroupPropertiesForFlags\(/i,
+    ];
+
+    // Group analytics patterns
+    const groupPatterns = [/posthog\.group\(/i];
+
+    lines.forEach((line, index) => {
+      const lineNumber = index + 1;
+
+      const addUsage = (pattern: RegExp, type: PostHogUsage["type"]) => {
+        const match = line.match(pattern);
+        if (match) {
+          usages.push({
+            file: filePath,
+            line: lineNumber,
+            column: line.indexOf(match[0]),
+            type,
+            context: match[0],
+          });
+        }
+      };
+
+      // Check each pattern type
+      importPatterns.forEach((pattern) => addUsage(pattern, "import"));
+      initializationPatterns.forEach((pattern) =>
+        addUsage(pattern, "initialization")
+      );
+      eventTrackingPatterns.forEach((pattern) =>
+        addUsage(pattern, "event tracking")
+      );
+      eventBlockingPatterns.forEach((pattern) =>
+        addUsage(pattern, "configuration")
+      );
+      userIdentificationPatterns.forEach((pattern) =>
+        addUsage(pattern, "identification")
+      );
+      optInOutPatterns.forEach((pattern) => addUsage(pattern, "configuration"));
+      queueManagementPatterns.forEach((pattern) =>
+        addUsage(pattern, "configuration")
+      );
+      featureFlagPatterns.forEach((pattern) =>
+        addUsage(pattern, "feature flags")
+      );
+      flagPropertyPatterns.forEach((pattern) =>
+        addUsage(pattern, "feature flags")
+      );
+      groupPatterns.forEach((pattern) => addUsage(pattern, "group analytics"));
+    });
+  }
+}

--- a/src/analysis/codeAnalyzer.ts
+++ b/src/analysis/codeAnalyzer.ts
@@ -139,7 +139,11 @@ export class CodeAnalyzer {
     const lines = text.split("\n");
 
     // Import patterns
-    const importPatterns = [/^import\s+posthog/i, /^from\s+posthog\s+import/i];
+    const importPatterns = [
+      /^import\s+posthog/i,
+      /^from\s+posthog\s+import/i,
+      /^import\s+posthog-analytics/i,
+    ];
 
     // Add initialization patterns back
     const initializationPatterns = [

--- a/src/api/posthogClient.ts
+++ b/src/api/posthogClient.ts
@@ -10,16 +10,20 @@ import {
 
 export class PostHogClient {
   private api!: AxiosInstance; // Using definite assignment assertion
-  private apiKey: string;
-  private apiHost: string;
+  private apiKey!: string; // Use definite assignment assertion
+  private apiHost!: string;
+  private context: vscode.ExtensionContext;
 
-  constructor() {
-    this.apiKey =
-      vscode.workspace.getConfiguration("posthog").get("apiKey") || "";
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    this.initializeFromSecrets();
+  }
+
+  async initializeFromSecrets() {
+    this.apiKey = (await this.getStoredApiKey()) || "";
     this.apiHost =
       vscode.workspace.getConfiguration("posthog").get("apiHost") ||
       "https://us.posthog.com";
-
     this.initializeApi();
   }
 
@@ -52,14 +56,23 @@ export class PostHogClient {
   /**
    * Update the API key
    */
-  updateApiKey(apiKey: string) {
+  async updateApiKey(apiKey: string) {
     this.apiKey = apiKey;
     this.initializeApi();
 
-    // Update config
-    return vscode.workspace
-      .getConfiguration("posthog")
-      .update("apiKey", apiKey, true);
+    // Store in secret storage instead of workspace config
+    const secretStorage = await this.getSecretStorage();
+    await secretStorage.store("posthog-api-key", apiKey);
+  }
+
+  private async getSecretStorage(): Promise<vscode.SecretStorage> {
+    // Get the extension context's secret storage
+    return this.context.secrets;
+  }
+
+  async getStoredApiKey(): Promise<string | undefined> {
+    const secretStorage = await this.getSecretStorage();
+    return await secretStorage.get("posthog-api-key");
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,35 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
-import { PostHogClient } from './api/posthogClient';
-import { ProjectsProvider } from './views/projectsProvider';
-import { InsightsProvider } from './views/insightsProvider';
-import { RecordingsProvider } from './views/recordingsProvider';
+import * as vscode from "vscode";
+import { PostHogClient } from "./api/posthogClient";
+import { ProjectsProvider } from "./views/projectsProvider";
+import { InsightsProvider } from "./views/insightsProvider";
+import { RecordingsProvider } from "./views/recordingsProvider";
+import { AnalysisProvider } from "./views/analysisProvider";
+import { CodeAnalyzer, PostHogUsage } from "./analysis/codeAnalyzer";
+
+// Debounce function
+function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout | undefined;
+  return function executedFunction(...args: Parameters<T>) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
-  console.log('PostHog extension is now active');
+  console.log("PostHog extension is now active");
 
   // Initialize API client
   const posthogClient = new PostHogClient();
@@ -20,22 +38,54 @@ export function activate(context: vscode.ExtensionContext) {
   const projectsProvider = new ProjectsProvider(context);
   const insightsProvider = new InsightsProvider(context);
   const recordingsProvider = new RecordingsProvider(context);
+  const analysisProvider = new AnalysisProvider(context);
 
   // Register tree views
-  const projectsView = vscode.window.createTreeView('posthogProjects', {
+  const projectsView = vscode.window.createTreeView("posthogProjects", {
     treeDataProvider: projectsProvider,
     showCollapseAll: true,
   });
 
-  const insightsView = vscode.window.createTreeView('posthogInsights', {
+  const insightsView = vscode.window.createTreeView("posthogInsights", {
     treeDataProvider: insightsProvider,
     showCollapseAll: true,
   });
 
-  const recordingsView = vscode.window.createTreeView('posthogRecordings', {
+  const recordingsView = vscode.window.createTreeView("posthogRecordings", {
     treeDataProvider: recordingsProvider,
     showCollapseAll: true,
   });
+
+  const analysisView = vscode.window.createTreeView("posthogAnalysis", {
+    treeDataProvider: analysisProvider,
+    showCollapseAll: true,
+  });
+
+  // Initialize code analyzer
+  const analyzer = new CodeAnalyzer();
+
+  // Create debounced analysis function
+  const debouncedAnalyze = debounce(async () => {
+    const usages = await analyzer.analyzeWorkspace();
+    analysisProvider.refresh(usages);
+  }, 1000); // 1 second debounce
+
+  // Listen for editor open events
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      debouncedAnalyze();
+    })
+  );
+
+  // Listen for document change events
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument(() => {
+      debouncedAnalyze();
+    })
+  );
+
+  // Initial analysis
+  debouncedAnalyze();
 
   // Register commands
   context.subscriptions.push(
@@ -43,12 +93,13 @@ export function activate(context: vscode.ExtensionContext) {
     projectsView,
     insightsView,
     recordingsView,
+    analysisView,
 
     // Set API Key command
-    vscode.commands.registerCommand('posthog.setApiKey', async () => {
+    vscode.commands.registerCommand("posthog.setApiKey", async () => {
       const apiKey = await vscode.window.showInputBox({
-        prompt: 'Enter your PostHog Personal API Key',
-        placeHolder: 'phx_xxxxxxxxxxxxxxxxxxxx',
+        prompt: "Enter your PostHog Personal API Key",
+        placeHolder: "phx_xxxxxxxxxxxxxxxxxxxx",
         password: true,
         ignoreFocusOut: true,
       });
@@ -61,20 +112,20 @@ export function activate(context: vscode.ExtensionContext) {
 
         if (isValid) {
           vscode.window.showInformationMessage(
-            'PostHog API key saved successfully!'
+            "PostHog API key saved successfully!"
           );
           projectsProvider.refresh();
         } else {
           vscode.window.showErrorMessage(
-            'Failed to connect to PostHog with the provided API key.'
+            "Failed to connect to PostHog with the provided API key."
           );
         }
       }
     }),
 
     // Set US API Host command
-    vscode.commands.registerCommand('posthog.setUsApiHost', async () => {
-      const usApiHost = 'https://us.posthog.com';
+    vscode.commands.registerCommand("posthog.setUsApiHost", async () => {
+      const usApiHost = "https://us.posthog.com";
       await posthogClient.updateApiHost(usApiHost);
       vscode.window.showInformationMessage(
         `PostHog API host set to US Cloud: ${usApiHost}`
@@ -83,8 +134,8 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     // Set EU API Host command
-    vscode.commands.registerCommand('posthog.setEuApiHost', async () => {
-      const euApiHost = 'https://eu.posthog.com';
+    vscode.commands.registerCommand("posthog.setEuApiHost", async () => {
+      const euApiHost = "https://eu.posthog.com";
       await posthogClient.updateApiHost(euApiHost);
       vscode.window.showInformationMessage(
         `PostHog API host set to EU Cloud: ${euApiHost}`
@@ -93,11 +144,11 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     // Set Custom API Host command
-    vscode.commands.registerCommand('posthog.setCustomApiHost', async () => {
+    vscode.commands.registerCommand("posthog.setCustomApiHost", async () => {
       const customApiHost = await vscode.window.showInputBox({
-        prompt: 'Enter your PostHog API host URL',
-        placeHolder: 'https://your-instance.posthog.com',
-        value: vscode.workspace.getConfiguration('posthog').get('apiHost'),
+        prompt: "Enter your PostHog API host URL",
+        placeHolder: "https://your-instance.posthog.com",
+        value: vscode.workspace.getConfiguration("posthog").get("apiHost"),
         ignoreFocusOut: true,
       });
 
@@ -111,15 +162,15 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     // Debug API Connection command
-    vscode.commands.registerCommand('posthog.debugConnection', async () => {
-      const apiKey = vscode.workspace.getConfiguration('posthog').get('apiKey');
+    vscode.commands.registerCommand("posthog.debugConnection", async () => {
+      const apiKey = vscode.workspace.getConfiguration("posthog").get("apiKey");
       const apiHost = vscode.workspace
-        .getConfiguration('posthog')
-        .get('apiHost');
+        .getConfiguration("posthog")
+        .get("apiHost");
 
       if (!apiKey) {
         vscode.window.showErrorMessage(
-          'No API key configured. Please set your PostHog API key first.'
+          "No API key configured. Please set your PostHog API key first."
         );
         return;
       }
@@ -127,7 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: 'Testing PostHog API connection...',
+          title: "Testing PostHog API connection...",
           cancellable: false,
         },
         async () => {
@@ -141,7 +192,7 @@ export function activate(context: vscode.ExtensionContext) {
               );
             } else {
               const message = `Failed to connect to PostHog API at ${apiHost}. Please check your API key and host settings.`;
-              const viewSettings = 'View Settings';
+              const viewSettings = "View Settings";
               const result = await vscode.window.showErrorMessage(
                 message,
                 viewSettings
@@ -149,13 +200,13 @@ export function activate(context: vscode.ExtensionContext) {
 
               if (result === viewSettings) {
                 await vscode.commands.executeCommand(
-                  'workbench.action.openSettings',
-                  'posthog'
+                  "workbench.action.openSettings",
+                  "posthog"
                 );
               }
             }
           } catch (error) {
-            console.error('Debug connection error:', error);
+            console.error("Debug connection error:", error);
             vscode.window.showErrorMessage(
               `Connection test error: ${
                 error instanceof Error ? error.message : String(error)
@@ -168,7 +219,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Copy Project Token command
     vscode.commands.registerCommand(
-      'posthog.copyProjectToken',
+      "posthog.copyProjectToken",
       async (apiToken: string, projectName: string) => {
         await vscode.env.clipboard.writeText(apiToken);
         vscode.window.showInformationMessage(
@@ -179,11 +230,11 @@ export function activate(context: vscode.ExtensionContext) {
 
     // List Insights command
     vscode.commands.registerCommand(
-      'posthog.listInsights',
+      "posthog.listInsights",
       async (projectId: number, projectName: string) => {
         insightsProvider.setProject(projectId, projectName);
         recordingsProvider.setProject(projectId, projectName);
-        await vscode.commands.executeCommand('posthogInsights.focus');
+        await vscode.commands.executeCommand("posthogInsights.focus");
         vscode.window.showInformationMessage(
           `Viewing insights for project: ${projectName}`
         );
@@ -192,7 +243,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // View Insight Details command
     vscode.commands.registerCommand(
-      'posthog.viewInsightDetails',
+      "posthog.viewInsightDetails",
       async (projectId: number, insightId: number, insightName: string) => {
         const insight = await posthogClient.getInsightDetails(
           projectId,
@@ -202,7 +253,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (insight) {
           // Create and show a webview panel to display the insight details
           const panel = vscode.window.createWebviewPanel(
-            'posthogInsightDetails',
+            "posthogInsightDetails",
             `PostHog Insight: ${insightName}`,
             vscode.ViewColumn.One,
             { enableScripts: true }
@@ -219,10 +270,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Create Annotation command
     vscode.commands.registerCommand(
-      'posthog.createAnnotation',
+      "posthog.createAnnotation",
       async (projectId: number, projectName: string) => {
         const content = await vscode.window.showInputBox({
-          prompt: 'Enter annotation content',
+          prompt: "Enter annotation content",
           placeHolder: 'e.g., "Released version 1.2.3"',
           ignoreFocusOut: true,
         });
@@ -230,16 +281,16 @@ export function activate(context: vscode.ExtensionContext) {
         if (content) {
           // Let the user choose if they want to use the current time or a custom date
           const dateOption = await vscode.window.showQuickPick(
-            ['Current time', 'Custom date/time'],
-            { placeHolder: 'Select when this annotation should be marked' }
+            ["Current time", "Custom date/time"],
+            { placeHolder: "Select when this annotation should be marked" }
           );
 
           let dateMarker: string | undefined = undefined;
 
-          if (dateOption === 'Custom date/time') {
+          if (dateOption === "Custom date/time") {
             const customDate = await vscode.window.showInputBox({
-              prompt: 'Enter date and time (ISO format)',
-              placeHolder: 'YYYY-MM-DDTHH:MM:SSZ (e.g., 2023-10-15T14:30:00Z)',
+              prompt: "Enter date and time (ISO format)",
+              placeHolder: "YYYY-MM-DDTHH:MM:SSZ (e.g., 2023-10-15T14:30:00Z)",
               ignoreFocusOut: true,
             });
 
@@ -269,13 +320,32 @@ export function activate(context: vscode.ExtensionContext) {
 
     // View Session Recordings command
     vscode.commands.registerCommand(
-      'posthog.viewSessionRecordings',
+      "posthog.viewSessionRecordings",
       async (projectId: number, projectName: string) => {
         recordingsProvider.setProject(projectId, projectName);
-        await vscode.commands.executeCommand('posthogRecordings.focus');
+        await vscode.commands.executeCommand("posthogRecordings.focus");
         vscode.window.showInformationMessage(
           `Viewing session recordings for project: ${projectName}`
         );
+      }
+    ),
+
+    // Code analysis commands
+    vscode.commands.registerCommand("posthog.analyzeCode", async () => {
+      const analyzer = new CodeAnalyzer();
+      const usages = await analyzer.analyzeWorkspace();
+      analysisProvider.refresh(usages);
+      vscode.commands.executeCommand("posthogAnalysis.focus");
+    }),
+
+    vscode.commands.registerCommand(
+      "posthog.openFileAtLocation",
+      async (usage: PostHogUsage) => {
+        const document = await vscode.workspace.openTextDocument(usage.file);
+        const position = new vscode.Position(usage.line - 1, usage.column);
+        await vscode.window.showTextDocument(document, {
+          selection: new vscode.Range(position, position),
+        });
       }
     )
   );
@@ -285,7 +355,7 @@ function getInsightDetailsWebview(insight: any): string {
   // Extract relevant information from the insight
   const name =
     insight.name || insight.derived_name || `Insight ${insight.short_id}`;
-  const description = insight.description || 'No description provided';
+  const description = insight.description || "No description provided";
 
   // Get theme type
   const isDarkTheme =
@@ -294,34 +364,34 @@ function getInsightDetailsWebview(insight: any): string {
   // Format created date
   const createdDate = insight.created_at
     ? new Date(insight.created_at).toLocaleDateString()
-    : 'Unknown date';
+    : "Unknown date";
 
   // Format creator information
   const creator = insight.created_by
     ? `${insight.created_by.first_name} ${insight.created_by.last_name}`.trim()
-    : 'Unknown user';
+    : "Unknown user";
 
   // Generate tags HTML if available
-  let tagsHtml = '';
+  let tagsHtml = "";
   if (insight.tags && insight.tags.length > 0) {
     tagsHtml = `
       <div class="tags">
         ${insight.tags
           .map((tag: string) => `<span class="tag">${tag}</span>`)
-          .join('')}
+          .join("")}
       </div>
     `;
   }
 
   // Generate a link to open the insight in PostHog
   const apiHost =
-    vscode.workspace.getConfiguration('posthog').get('apiHost') ||
-    'https://us.posthog.com';
+    vscode.workspace.getConfiguration("posthog").get("apiHost") ||
+    "https://us.posthog.com";
   const insightLink = `${apiHost}/insights/${insight.short_id}`;
 
   // Prepare chart data
-  let chartHtml = '';
-  let chartScript = '';
+  let chartHtml = "";
+  let chartScript = "";
 
   try {
     // Check if insight has result data
@@ -376,12 +446,12 @@ function getInsightDetailsWebview(insight: any): string {
       }
     }
   } catch (error) {
-    console.error('Error creating chart:', error);
-    chartHtml = '<p>Error rendering chart visualization</p>';
+    console.error("Error creating chart:", error);
+    chartHtml = "<p>Error rendering chart visualization</p>";
   }
 
   // Generate result visualization if possible
-  let resultHtml = '';
+  let resultHtml = "";
   if (insight.result) {
     try {
       resultHtml = `
@@ -395,7 +465,7 @@ function getInsightDetailsWebview(insight: any): string {
         </div>
       `;
     } catch (error) {
-      resultHtml = '<p>Error rendering result preview</p>';
+      resultHtml = "<p>Error rendering result preview</p>";
     }
   }
 
@@ -474,7 +544,7 @@ function getInsightDetailsWebview(insight: any): string {
           background-color: var(--vscode-editor-background);
           border-radius: 4px;
           box-shadow: 0 2px 8px ${
-            isDarkTheme ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.15)'
+            isDarkTheme ? "rgba(0, 0, 0, 0.5)" : "rgba(0, 0, 0, 0.15)"
           };
         }
       </style>
@@ -500,11 +570,11 @@ function getInsightDetailsWebview(insight: any): string {
           </tr>
           <tr>
             <th>Last Refresh</th>
-            <td>${insight.last_refresh || 'N/A'}</td>
+            <td>${insight.last_refresh || "N/A"}</td>
           </tr>
           <tr>
             <th>Query Status</th>
-            <td>${insight.query_status || 'N/A'}</td>
+            <td>${insight.query_status || "N/A"}</td>
           </tr>
         </table>
         
@@ -524,7 +594,7 @@ function getInsightDetailsWebview(insight: any): string {
  * Prepare chart data based on insight type and result data
  */
 function prepareChartData(insight: any): any {
-  let chartType = 'line';
+  let chartType = "line";
   let labels: string[] = [];
   let datasets: any[] = [];
 
@@ -535,16 +605,16 @@ function prepareChartData(insight: any): any {
       // Map PostHog display types to Chart.js chart types
       const displayType = insight.filters?.display || insight.query?.display;
       switch (displayType) {
-        case 'ActionsBarValue':
-        case 'ActionsPie':
-          chartType = 'pie';
+        case "ActionsBarValue":
+        case "ActionsPie":
+          chartType = "pie";
           break;
-        case 'ActionsBar':
-          chartType = 'bar';
+        case "ActionsBar":
+          chartType = "bar";
           break;
-        case 'ActionsLineGraph':
+        case "ActionsLineGraph":
         default:
-          chartType = 'line';
+          chartType = "line";
           break;
       }
     }
@@ -554,7 +624,7 @@ function prepareChartData(insight: any): any {
       // Handle trend/time series data
       if (insight.result[0]?.days || insight.result[0]?.dates) {
         // It's a time series chart
-        const timeField = insight.result[0]?.days ? 'days' : 'dates';
+        const timeField = insight.result[0]?.days ? "days" : "dates";
         labels = insight.result[0][timeField] || [];
 
         datasets = insight.result.map((series: any, index: number) => {
@@ -581,7 +651,7 @@ function prepareChartData(insight: any): any {
           ...new Set(breakdownData.map((item: any) => item.breakdown_value)),
         ];
 
-        labels = uniqueBreakdowns.map((value: any) => String(value || 'None'));
+        labels = uniqueBreakdowns.map((value: any) => String(value || "None"));
 
         const seriesData = uniqueBreakdowns.map((breakdown: any) => {
           const matchingItems = breakdownData.filter(
@@ -595,7 +665,7 @@ function prepareChartData(insight: any): any {
 
         datasets = [
           {
-            label: 'Breakdown',
+            label: "Breakdown",
             data: seriesData,
             backgroundColor: labels.map((_, i) => {
               const hue = (i * 137) % 360;
@@ -607,10 +677,10 @@ function prepareChartData(insight: any): any {
       }
       // Handle funnel data
       else if (
-        insight.filters?.insight === 'FUNNELS' ||
+        insight.filters?.insight === "FUNNELS" ||
         insight.result.some((item: any) => item.action_id !== undefined)
       ) {
-        chartType = 'bar';
+        chartType = "bar";
         const steps = insight.result;
 
         labels = steps.map(
@@ -621,27 +691,27 @@ function prepareChartData(insight: any): any {
 
         datasets = [
           {
-            label: 'Conversion',
+            label: "Conversion",
             data: data,
-            backgroundColor: 'rgba(66, 153, 225, 0.6)',
-            borderColor: 'rgb(66, 153, 225)',
+            backgroundColor: "rgba(66, 153, 225, 0.6)",
+            borderColor: "rgb(66, 153, 225)",
             borderWidth: 1,
           },
         ];
       }
       // Fallback for other types of results
       else {
-        chartType = 'bar';
+        chartType = "bar";
         labels = insight.result.map((_: any, i: number) => `Item ${i + 1}`);
 
         datasets = [
           {
-            label: 'Values',
+            label: "Values",
             data: insight.result.map((item: any) =>
-              typeof item === 'number' ? item : item.count || item.value || 0
+              typeof item === "number" ? item : item.count || item.value || 0
             ),
-            backgroundColor: 'rgba(66, 153, 225, 0.6)',
-            borderColor: 'rgb(66, 153, 225)',
+            backgroundColor: "rgba(66, 153, 225, 0.6)",
+            borderColor: "rgb(66, 153, 225)",
             borderWidth: 1,
           },
         ];
@@ -660,10 +730,10 @@ function prepareChartData(insight: any): any {
         maintainAspectRatio: false,
         plugins: {
           legend: {
-            position: 'top',
+            position: "top",
             labels: {
               font: {
-                family: 'var(--vscode-font-family)',
+                family: "var(--vscode-font-family)",
               },
             },
           },
@@ -672,12 +742,12 @@ function prepareChartData(insight: any): any {
           },
         },
         scales:
-          chartType !== 'pie'
+          chartType !== "pie"
             ? {
                 x: {
                   ticks: {
                     font: {
-                      family: 'var(--vscode-font-family)',
+                      family: "var(--vscode-font-family)",
                     },
                   },
                   grid: {},
@@ -685,7 +755,7 @@ function prepareChartData(insight: any): any {
                 y: {
                   ticks: {
                     font: {
-                      family: 'var(--vscode-font-family)',
+                      family: "var(--vscode-font-family)",
                     },
                   },
                   grid: {},
@@ -695,7 +765,7 @@ function prepareChartData(insight: any): any {
       },
     };
   } catch (error) {
-    console.error('Error preparing chart data:', error);
+    console.error("Error preparing chart data:", error);
     return null;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,13 +26,14 @@ function debounce<T extends (...args: any[]) => any>(
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
   console.log("PostHog extension is now active");
 
-  // Initialize API client
-  const posthogClient = new PostHogClient();
+  // Initialize PostHogClient
+  const posthogClient = new PostHogClient(context);
+  await posthogClient.initializeFromSecrets();
 
   // Initialize tree view providers
   const projectsProvider = new ProjectsProvider(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { PostHogClient } from "./api/posthogClient";
 import { ProjectsProvider } from "./views/projectsProvider";
 import { InsightsProvider } from "./views/insightsProvider";
-import { RecordingsProvider } from "./views/recordingsProvider";
+// import { RecordingsProvider } from "./views/recordingsProvider";
 import { AnalysisProvider } from "./views/analysisProvider";
 import { CodeAnalyzer, PostHogUsage } from "./analysis/codeAnalyzer";
 
@@ -38,7 +38,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize tree view providers
   const projectsProvider = new ProjectsProvider(context);
   const insightsProvider = new InsightsProvider(context);
-  const recordingsProvider = new RecordingsProvider(context);
+  // const recordingsProvider = new RecordingsProvider(context);
   const analysisProvider = new AnalysisProvider(context);
 
   // Register tree views
@@ -52,10 +52,10 @@ export async function activate(context: vscode.ExtensionContext) {
     showCollapseAll: true,
   });
 
-  const recordingsView = vscode.window.createTreeView("posthogRecordings", {
-    treeDataProvider: recordingsProvider,
-    showCollapseAll: true,
-  });
+  // const recordingsView = vscode.window.createTreeView("posthogRecordings", {
+  //   treeDataProvider: recordingsProvider,
+  //   showCollapseAll: true,
+  // });
 
   const analysisView = vscode.window.createTreeView("posthogAnalysis", {
     treeDataProvider: analysisProvider,
@@ -93,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Tree views
     projectsView,
     insightsView,
-    recordingsView,
+    // recordingsView,
     analysisView,
 
     // Set API Key command
@@ -234,7 +234,7 @@ export async function activate(context: vscode.ExtensionContext) {
       "posthog.listInsights",
       async (projectId: number, projectName: string) => {
         insightsProvider.setProject(projectId, projectName);
-        recordingsProvider.setProject(projectId, projectName);
+        // recordingsProvider.setProject(projectId, projectName);
         await vscode.commands.executeCommand("posthogInsights.focus");
         vscode.window.showInformationMessage(
           `Viewing insights for project: ${projectName}`
@@ -320,16 +320,16 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
 
     // View Session Recordings command
-    vscode.commands.registerCommand(
-      "posthog.viewSessionRecordings",
-      async (projectId: number, projectName: string) => {
-        recordingsProvider.setProject(projectId, projectName);
-        await vscode.commands.executeCommand("posthogRecordings.focus");
-        vscode.window.showInformationMessage(
-          `Viewing session recordings for project: ${projectName}`
-        );
-      }
-    ),
+    // vscode.commands.registerCommand(
+    //   "posthog.viewSessionRecordings",
+    //   async (projectId: number, projectName: string) => {
+    //     recordingsProvider.setProject(projectId, projectName);
+    //     await vscode.commands.executeCommand("posthogRecordings.focus");
+    //     vscode.window.showInformationMessage(
+    //       `Viewing session recordings for project: ${projectName}`
+    //     );
+    //   }
+    // ),
 
     // Code analysis commands
     vscode.commands.registerCommand("posthog.analyzeCode", async () => {

--- a/src/types/tree-sitter.d.ts
+++ b/src/types/tree-sitter.d.ts
@@ -1,0 +1,39 @@
+declare module "tree-sitter" {
+  export class Parser {
+    setLanguage(language: any): void;
+    parse(input: string): Tree;
+  }
+
+  export class Tree {
+    rootNode: SyntaxNode;
+  }
+
+  export class SyntaxNode {
+    type: string;
+    text: string;
+    startPosition: { row: number; column: number };
+    query(queryString: string): Query;
+  }
+
+  export class Query {
+    matches(): QueryMatch[];
+  }
+
+  export interface QueryMatch {
+    captures: QueryCapture[];
+  }
+
+  export interface QueryCapture {
+    node: SyntaxNode;
+  }
+}
+
+declare module "tree-sitter-python" {
+  const Python: any;
+  export = Python;
+}
+
+declare module "tree-sitter-typescript" {
+  const TypeScript: any;
+  export = TypeScript;
+}

--- a/src/views/analysisProvider.ts
+++ b/src/views/analysisProvider.ts
@@ -1,0 +1,113 @@
+import * as vscode from "vscode";
+import { PostHogUsage } from "../analysis/codeAnalyzer";
+import * as fs from "fs";
+import * as path from "path";
+
+export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    AnalysisItem | undefined | null | void
+  > = new vscode.EventEmitter<AnalysisItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<
+    AnalysisItem | undefined | null | void
+  > = this._onDidChangeTreeData.event;
+
+  private usages: PostHogUsage[] = [];
+
+  constructor(private context: vscode.ExtensionContext) {}
+
+  refresh(usages: PostHogUsage[]) {
+    this.usages = usages;
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: AnalysisItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: AnalysisItem): Thenable<AnalysisItem[]> {
+    if (!element) {
+      return Promise.resolve(this.getRootItems());
+    }
+    if (element.isFile) {
+      return Promise.resolve(this.getFileUsages(element.filePath));
+    }
+    return Promise.resolve([]);
+  }
+
+  private getRootItems(): AnalysisItem[] {
+    const usagesByFile = this.groupUsagesByFile();
+    return Object.entries(usagesByFile)
+      .sort(([filePathA], [filePathB]) => filePathA.localeCompare(filePathB))
+      .map(([filePath, fileUsages]) => {
+        const item = new AnalysisItem(
+          path.basename(filePath),
+          vscode.TreeItemCollapsibleState.Expanded,
+          true,
+          filePath
+        );
+        item.iconPath = this.getFileIcon(filePath);
+        item.tooltip = filePath;
+        return item;
+      });
+  }
+
+  private getFileIcon(filePath: string): vscode.ThemeIcon {
+    return new vscode.ThemeIcon("file-code");
+  }
+
+  private getFileUsages(filePath: string): AnalysisItem[] {
+    const fileUsages = this.usages.filter((usage) => usage.file === filePath);
+    return fileUsages
+      .sort((a, b) =>
+        `${a.type}: ${a.context}`.localeCompare(`${b.type}: ${b.context}`)
+      )
+      .map((usage) => {
+        const item = new AnalysisItem(
+          `${usage.type}: ${usage.context}`,
+          vscode.TreeItemCollapsibleState.None,
+          false,
+          filePath
+        );
+        item.tooltip = this.getCodePreview(filePath, usage.line);
+        item.command = {
+          command: "posthog.openFileAtLocation",
+          title: "Open File",
+          arguments: [usage],
+        };
+        return item;
+      });
+  }
+
+  private groupUsagesByFile(): { [key: string]: PostHogUsage[] } {
+    return this.usages.reduce((acc, usage) => {
+      if (!acc[usage.file]) {
+        acc[usage.file] = [];
+      }
+      acc[usage.file].push(usage);
+      return acc;
+    }, {} as { [key: string]: PostHogUsage[] });
+  }
+
+  private getCodePreview(filePath: string, lineNumber: number): string {
+    try {
+      const content = fs.readFileSync(filePath, "utf-8");
+      const lines = content.split("\n");
+      const start = Math.max(0, lineNumber - 2);
+      const end = Math.min(lines.length, lineNumber + 2);
+      return lines.slice(start, end).join("\n");
+    } catch (error) {
+      return "Unable to load code preview";
+    }
+  }
+}
+
+class AnalysisItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly isFile: boolean,
+    public readonly filePath: string
+  ) {
+    super(label, collapsibleState);
+  }
+}

--- a/src/views/analysisProvider.ts
+++ b/src/views/analysisProvider.ts
@@ -32,13 +32,12 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
       return Promise.resolve(this.getFileUsages(element.filePath));
     }
     if (element.usage?.warning) {
-      // Split warnings by semicolon and create a warning item for each
       const warnings = element.usage.warning
         .split(";")
         .map((w) => w.trim())
         .filter((w) => w);
       return Promise.resolve(
-        warnings.map((warning) => this.createWarningItem(warning))
+        warnings.map((warning) => this.createWarningItem(warning, element))
       );
     }
     return Promise.resolve([]);
@@ -110,29 +109,37 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
       });
   }
 
-  private createWarningItem(warning: string): AnalysisItem {
+  private createWarningItem(
+    warning: string,
+    parent?: AnalysisItem
+  ): AnalysisItem {
     const item = new AnalysisItem(
       warning,
       vscode.TreeItemCollapsibleState.None,
       false,
-      "",
-      undefined
+      parent?.filePath || "",
+      undefined,
+      parent
     );
     item.iconPath = new vscode.ThemeIcon("warning");
     item.contextValue = "warning";
-
-    // Add yellow highlighting
     item.tooltip = warning;
-    item.description = ""; // Ensure no additional text appears after the label
-
-    // Use VS Code's built-in warning colors
-    item.resourceUri = vscode.Uri.parse("warning"); // This is a hack to get the warning color
+    item.description = "";
+    item.resourceUri = vscode.Uri.parse("warning");
     item.decorationProvider = true;
 
-    // Set label formatting with yellow theme color
+    // Add the parent usage information to the warning item
+    if (item.parent?.usage) {
+      item.command = {
+        command: "posthog.openFileAtLocation",
+        title: "Open File",
+        arguments: [item.parent.usage],
+      };
+    }
+
     item.label = {
       label: warning,
-      highlights: [[0, warning.length]], // Highlight entire text
+      highlights: [[0, warning.length]],
     };
 
     return item;
@@ -163,11 +170,12 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
 
 class AnalysisItem extends vscode.TreeItem {
   constructor(
-    public readonly label: string | vscode.TreeItemLabel,
+    public label: string | vscode.TreeItemLabel,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly isFile: boolean,
     public readonly filePath: string,
-    public readonly usage?: PostHogUsage
+    public readonly usage?: PostHogUsage,
+    public readonly parent?: AnalysisItem
   ) {
     super(label, collapsibleState);
   }

--- a/src/views/analysisProvider.ts
+++ b/src/views/analysisProvider.ts
@@ -32,7 +32,14 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
       return Promise.resolve(this.getFileUsages(element.filePath));
     }
     if (element.usage?.warning) {
-      return Promise.resolve([this.createWarningItem(element.usage.warning)]);
+      // Split warnings by semicolon and create a warning item for each
+      const warnings = element.usage.warning
+        .split(";")
+        .map((w) => w.trim())
+        .filter((w) => w);
+      return Promise.resolve(
+        warnings.map((warning) => this.createWarningItem(warning))
+      );
     }
     return Promise.resolve([]);
   }
@@ -86,7 +93,11 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
         // Add warning badge if there's a warning
         if (usage.warning) {
           item.badge = new vscode.ThemeIcon("warning");
-          item.description = "⚠️ 1"; // Add warning count in the description
+          // Count the number of warnings by splitting on semicolons
+          const warningCount = usage.warning
+            .split(";")
+            .filter((w) => w.trim()).length;
+          item.description = `⚠️ ${warningCount}`; // Show actual count of warnings
         }
 
         item.tooltip = this.getCodePreview(filePath, usage.line);

--- a/src/views/analysisProvider.ts
+++ b/src/views/analysisProvider.ts
@@ -31,6 +31,9 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
     if (element.isFile) {
       return Promise.resolve(this.getFileUsages(element.filePath));
     }
+    if (element.usage?.warning) {
+      return Promise.resolve([this.createWarningItem(element.usage.warning)]);
+    }
     return Promise.resolve([]);
   }
 
@@ -39,12 +42,20 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
     return Object.entries(usagesByFile)
       .sort(([filePathA], [filePathB]) => filePathA.localeCompare(filePathB))
       .map(([filePath, fileUsages]) => {
+        const warningCount = fileUsages.filter((u) => u.warning).length;
         const item = new AnalysisItem(
           path.basename(filePath),
           vscode.TreeItemCollapsibleState.Expanded,
           true,
           filePath
         );
+
+        // Add warning count badge to files that have warnings
+        if (warningCount > 0) {
+          item.badge = new vscode.ThemeIcon("warning");
+          item.description = `⚠️ ${warningCount}`; // Show total warnings in the file
+        }
+
         item.iconPath = this.getFileIcon(filePath);
         item.tooltip = filePath;
         return item;
@@ -64,10 +75,20 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
       .map((usage) => {
         const item = new AnalysisItem(
           `${usage.type}: ${usage.context}`,
-          vscode.TreeItemCollapsibleState.None,
+          usage.warning
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.None,
           false,
-          filePath
+          filePath,
+          usage
         );
+
+        // Add warning badge if there's a warning
+        if (usage.warning) {
+          item.badge = new vscode.ThemeIcon("warning");
+          item.description = "⚠️ 1"; // Add warning count in the description
+        }
+
         item.tooltip = this.getCodePreview(filePath, usage.line);
         item.command = {
           command: "posthog.openFileAtLocation",
@@ -76,6 +97,34 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
         };
         return item;
       });
+  }
+
+  private createWarningItem(warning: string): AnalysisItem {
+    const item = new AnalysisItem(
+      warning,
+      vscode.TreeItemCollapsibleState.None,
+      false,
+      "",
+      undefined
+    );
+    item.iconPath = new vscode.ThemeIcon("warning");
+    item.contextValue = "warning";
+
+    // Add yellow highlighting
+    item.tooltip = warning;
+    item.description = ""; // Ensure no additional text appears after the label
+
+    // Use VS Code's built-in warning colors
+    item.resourceUri = vscode.Uri.parse("warning"); // This is a hack to get the warning color
+    item.decorationProvider = true;
+
+    // Set label formatting with yellow theme color
+    item.label = {
+      label: warning,
+      highlights: [[0, warning.length]], // Highlight entire text
+    };
+
+    return item;
   }
 
   private groupUsagesByFile(): { [key: string]: PostHogUsage[] } {
@@ -103,11 +152,15 @@ export class AnalysisProvider implements vscode.TreeDataProvider<AnalysisItem> {
 
 class AnalysisItem extends vscode.TreeItem {
   constructor(
-    public readonly label: string,
+    public readonly label: string | vscode.TreeItemLabel,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly isFile: boolean,
-    public readonly filePath: string
+    public readonly filePath: string,
+    public readonly usage?: PostHogUsage
   ) {
     super(label, collapsibleState);
   }
+
+  decorationProvider?: boolean;
+  badge?: vscode.ThemeIcon;
 }

--- a/src/views/insightsProvider.ts
+++ b/src/views/insightsProvider.ts
@@ -28,7 +28,7 @@ export class InsightsProvider
   private insights: PostHogInsight[] = [];
 
   constructor(private context: vscode.ExtensionContext) {
-    this.client = new PostHogClient();
+    this.client = new PostHogClient(context);
   }
 
   refresh(): void {

--- a/src/views/projectsProvider.ts
+++ b/src/views/projectsProvider.ts
@@ -21,7 +21,7 @@ export class ProjectsProvider
   private projects: PostHogProject[] = [];
 
   constructor(private context: vscode.ExtensionContext) {
-    this.client = new PostHogClient();
+    this.client = new PostHogClient(context);
   }
 
   refresh(): void {
@@ -36,9 +36,7 @@ export class ProjectsProvider
     if (!element) {
       // Root level - fetch projects
       try {
-        const hasApiKey = !!vscode.workspace
-          .getConfiguration("posthog")
-          .get("apiKey");
+        const hasApiKey = !!(await this.client.getStoredApiKey());
 
         if (!hasApiKey) {
           return [new SetupRequiredItem()];

--- a/src/views/recordingsProvider.ts
+++ b/src/views/recordingsProvider.ts
@@ -30,7 +30,7 @@ export class RecordingsProvider
   private recordings: PostHogSessionRecording[] = [];
 
   constructor(private context: vscode.ExtensionContext) {
-    this.client = new PostHogClient();
+    this.client = new PostHogClient(context);
   }
 
   refresh(): void {


### PR DESCRIPTION
## Changes
- New SDK usage static analysis view in the extension aka PostHog Doctor mode with 4 tracked warnings:
    - Dynamic user events
    - Too many captured properties at once (>25)
    - Setting up PostHog without a reverse proxy
    - Similar event names across the codebase
- Save API secret in vscode's native SecretStorage
- Remove unusable session recordings view

## How did you test this code?
Extension debugger